### PR TITLE
Update workflows and documentation templates to v0.1

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,37 @@
+name: Update changelog
+
+on:
+  push:
+    tags: v**
+
+jobs:
+  changelog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Fetch tags
+        run: git fetch --tags
+      - name: Generate changelog
+        uses: charmixer/auto-changelog-action@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          exclude-labels: duplicate,question,invalid,wontfix,auto-update
+      - name: Create Changelog Pull Request
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update CHANGELOG.md
+          title: 'Update CHANGELOG.md'
+          labels: auto-update
+          branch: auto-update-changelog
+          body: Update CHANGELOG.md with information from latest release
+      - name: Merge Changelog Pull Request
+        if: env.PULL_REQUEST_NUMBER != null
+        uses: juliangruber/merge-pull-request-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ env.PULL_REQUEST_NUMBER }}
+          method: merge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Formatters & Tests
+
+on:
+  push:
+    branches: master
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Fetch tags
+        run: git fetch --tags
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v7
+      - name: Run checks
+        run: sbt ci-test

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,41 @@
+name: Update documentation
+
+on:
+  push:
+    branches: master
+    tags: v**
+
+jobs:
+  documentation:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Fetch tags
+        run: git fetch --tags
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v7
+      - name: Generate documentation
+        run: sbt ci-docs
+        env:
+          DOWNLOAD_INFO_FROM_GITHUB: true
+      - name: Create Documentation Pull Request
+        uses: peter-evans/create-pull-request@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          commit-message: Update documentation and other files
+          title: 'Update documentation and other files'
+          labels: auto-update,documentation
+          branch: auto-update-docs
+          body: Update documentation and other files with latest changes.
+      - name: Merge Documentation Pull Request
+        if: env.PULL_REQUEST_NUMBER != null
+        uses: juliangruber/merge-pull-request-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          number: ${{ env.PULL_REQUEST_NUMBER }}
+          method: merge

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+    branches: master
+    tags: v**
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout project
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Fetch tags
+        run: git fetch --tags
+      - name: Setup Scala
+        uses: olafurpg/setup-scala@v7
+      - name: Setup GPG
+        uses: olafurpg/setup-gpg@v2
+      - name: Release new version
+        run: sbt ci-release
+        env:
+          DOWNLOAD_INFO_FROM_GITHUB: true
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PGP_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+          PGP_SECRET: ${{ secrets.PGP_SECRET }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}

--- a/docs/AUTHORS.md
+++ b/docs/AUTHORS.md
@@ -1,0 +1,13 @@
+# Authors
+
+## Maintainers
+
+The maintainers of the project are:
+
+@COLLABORATORS@
+
+## Contributors
+
+These are the people that have contributed to the _@NAME@_ project:
+
+@CONTRIBUTORS@

--- a/docs/CODE_OF_CONDUCT.md
+++ b/docs/CODE_OF_CONDUCT.md
@@ -1,0 +1,18 @@
+# Code of Conduct
+
+We are committed to providing a friendly, safe and welcoming
+environment for all, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal
+appearance, body size, race, ethnicity, age, religion, nationality, or
+other such characteristics.
+
+Everyone is expected to follow the
+[Scala Code of Conduct](https://typelevel.org/code-of-conduct.html) when
+discussing the project on the available communication channels. If you
+are being harassed, please contact us immediately so that we can
+support you.
+
+## Moderation
+
+For any questions, concerns, or moderation requests please contact a
+[member of the project](AUTHORS.md#maintainers).

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+Discussion around _@NAME@_ happens in the [GitHub issues](https://github.com/@REPO@/issues) and [pull requests](https://github.com/@REPO@/pulls).
+
+Feel free to open an issue if you notice a bug, have an idea for a feature, or have a question about
+the code. Pull requests are also welcome.
+
+People are expected to follow the [Code of Conduct](CODE_OF_CONDUCT.md) when discussing _@NAME@_ on the Github page or other venues.
+
+If you are being harassed, please contact one of [us](AUTHORS.md#maintainers) immediately so that we can support you. In case you cannot get in touch with us please write an email to [@ORG_NAME@](mailto:@ORG_EMAIL@).
+
+## How can I help?
+
+_@NAME@_ follows a standard [fork and pull](https://help.github.com/articles/using-pull-requests/) model for contributions via GitHub pull requests.
+
+The process is simple:
+
+ 1. Find something you want to work on
+ 2. Let us know you are working on it via GitHub issues/pull requests
+ 3. Implement your contribution
+ 4. Write tests
+ 5. Update the documentation
+ 6. Submit pull request
+
+You will be automatically included in the [AUTHORS.md](AUTHORS.md#contributors) file as contributor in the next release.
+
+If you encounter any confusion or frustration during the contribution process, please create a GitHub issue and we'll do our best to improve the process.

--- a/docs/NOTICE.md
+++ b/docs/NOTICE.md
@@ -1,0 +1,5 @@
+@NAME@
+
+Copyright (c) @YEAR_RANGE@ @ORG_NAME@. All rights reserved.
+
+Licensed under @LICENSE@. See [LICENSE](LICENSE) for terms.


### PR DESCRIPTION
- First version of the documentation files, including `AUTHORS.md`, `CODE_OF_CONDUCT.md`, `CONTRIBUTING.md` and `NOTICE.md`
- First version of the workflow files, including workflows for updating changelog and docs, for running the release task and executing the ci.

In order for running, `ci`, `docs` and `release` workflows the following aliases (with the same, or different commands) should be created in `build.sbt`:

```scala
addCommandAlias("ci-test", "fix --check; mdoc; test; publishLocal; all scripted")
addCommandAlias("ci-docs", "mdoc; headerCreateAll")

//Not needed if using `sbt-ci-release`
addCommandAlias("ci-release", "publish")
```