### PR TITLE
First run scalafix, then scalafmt

### DIFF
--- a/sbt-fix/src/main/scala/com/alejandrohdezma/sbt/fix/FixCommandPlugin.scala
+++ b/sbt-fix/src/main/scala/com/alejandrohdezma/sbt/fix/FixCommandPlugin.scala
@@ -52,7 +52,7 @@ object FixCommandPlugin extends AutoPlugin {
         .map(c => s"$c:scalafix")
         .mkString(" ")
 
-      Command.process(s"all scalafmtAll scalafmtSbt; all $scalafixCommand", state)
+      Command.process(s"all $scalafixCommand; all scalafmtAll scalafmtSbt", state)
     case (state, args) =>
       state.log.error(s"Invalid argument `${args.mkString(" ")}`")
       state.log.error(s"The only argument allowed is `--check`")


### PR DESCRIPTION
this makes sure, that even if scalafix produces a malformed result, scalafmt always cleans it up afterwards