### PR TITLE
Continue-on-error `fix --check`, with `ci` alias and CI Markdown report

### DIFF
--- a/.github/docs/README.md
+++ b/.github/docs/README.md
@@ -18,34 +18,72 @@ This task can be used to launch both `scalafmt` and `scalafix` in all supported 
 fix
 ```
 
-It can also be used for checking that all files have been fixed with both tools, exiting with non-zero code on violations, by appending the `--check` argument (which can be used in CI to check formatting easily).
+It can also be used for checking that all files have been fixed with both tools, exiting with non-zero code on violations, by appending the `--check` argument (which can be used in CI to check formatting easily). A `ci` task alias is also provided as a shorter form of `fix --check`.
 
 ```sbt
 fix --check
+ci
 ```
 
-Both usages can be scoped to a specific project in the build:
+All usages can be scoped to a specific project in the build:
 
 ```sbt
 my-project/fix
 my-project/fix --check
+my-project/ci
 ```
 
 ## Chaining additional tasks
 
-`fix` and `fix --check` can be extended with extra format/check tasks via the `fixExtra` and `fixCheckExtra` settings. Whatever is listed there is run sequentially **after** the built-in `scalafmt` + `scalafix` steps. Both settings hold `Seq[Def.Initialize[Task[Unit]]]`, so any of the following shapes work:
+`fix` and `fix --check` can be extended with extra format/check tasks via the `fixExtra` and `fixCheckExtra` settings. Whatever is listed there is run **after** the built-in `scalafmt` + `scalafix` steps.
+
+`fixExtra` holds `Seq[Def.Initialize[Task[Unit]]]`, so any of the following shapes work:
 
 ```sbt
 // 1. A plain task key
-fixExtra      += myFormatTask
-fixCheckExtra += myFormatCheckTask
+fixExtra += myFormatTask
 
 // 2. An input-task invocation (e.g. shelling out to a CLI plugin)
-fixExtra      += someInputKey.toTask(" --write")
-fixCheckExtra += someInputKey.toTask(" --check")
+fixExtra += someInputKey.toTask(" --write")
 
 // 3. An inline task literal
-fixExtra      += Def.task { /* anything returning Unit */ }
+fixExtra += Def.task { /* anything returning Unit */ }
+```
+
+`fixCheckExtra` holds `Seq[NamedCheck]`. A `NamedCheck` is a `(name, task)` pair shown in the labelled CI output and the Markdown summary table. The `.named(...)` combinator on any task initializer wraps it as a `NamedCheck`:
+
+```sbt
+fixCheckExtra += myFormatCheckTask.named("my-linter")
+fixCheckExtra += someInputKey.toTask(" --check").named("foo")
+fixCheckExtra += Def.task { /* anything */ }.named("bar")
+fixCheckExtra += NamedCheck("baz", myLinterTask)            // explicit form
 ```
 
 Defaults are empty seqs, so projects that don't set these see the original behavior.
+
+## `fix --check` output
+
+`fix --check` keeps going even when an earlier check fails so a single CI run surfaces every formatter/linter violation at once. It exits with a non-zero status if any check failed.
+
+When the `CI` environment variable is set (GitHub Actions, GitLab, CircleCI, Travis, Buildkite, etc. all do this by default), the task additionally:
+
+1. Prints the ordered plan of checks.
+2. Logs a `==> <check>` banner before each check.
+3. Logs a `PASS` / `FAIL` summary block after all checks finish.
+4. Writes the same summary as a Markdown status table. If `GITHUB_STEP_SUMMARY` is defined (the GitHub Actions runtime sets it), the table is appended to that file and shows up on the [workflow run summary page](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-commands#adding-a-job-summary). Otherwise it is written to `target/fix-check-summary.md`.
+
+Local invocations (no `CI` env var) stay quiet — only the underlying scalafmt/scalafix output appears.
+
+Markdown sample:
+
+```md
+# CI checks (2.12.20)
+
+| Check | Status |
+| --- | --- |
+| scalafmt-check | PASS |
+| scalafmt-sbt-check | PASS |
+| scalafix-check | FAIL |
+```
+
+The Scala version is included in the heading so a cross-built run (`+fix --check`) produces a distinct, identifiable block on the GitHub summary page for each Scala version.

--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 ThisBuild / scalaVersion                  := _root_.scalafix.sbt.BuildInfo.scala212
 ThisBuild / organization                  := "com.alejandrohdezma"
 ThisBuild / pluginCrossBuild / sbtVersion := "1.2.8"
-ThisBuild / versionPolicyIntention        := Compatibility.BinaryAndSourceCompatible
+ThisBuild / versionPolicyIntention        := Compatibility.None
 
 addCommandAlias("ci-test", "fix --check; versionPolicyCheck; mdoc")
 addCommandAlias("ci-docs", "github; mdoc; headerCreateAll")

--- a/modules/sbt-fix/src/main/scala/com/alejandrohdezma/sbt/fix/FixCommandPlugin.scala
+++ b/modules/sbt-fix/src/main/scala/com/alejandrohdezma/sbt/fix/FixCommandPlugin.scala
@@ -16,6 +16,7 @@
 
 package com.alejandrohdezma.sbt.fix
 
+import sbt.Keys._
 import sbt._
 
 import org.scalafmt.sbt.ScalafmtPlugin
@@ -32,22 +33,70 @@ import scalafix.sbt.ScalafixPlugin.autoImport.scalafixAll
   *
   * The task can be scoped to a specific project: `my-project/fix` or `my-project/fix --check`.
   *
-  * Additional tasks can be plugged in via the `fixExtra` / `fixCheckExtra` settings; they run after the built-in
-  * scalafmt/scalafix steps.
+  * In check mode the plugin runs every check even if earlier ones fail. When the `CI` environment variable is set, the
+  * run also prints a labelled banner per check, logs a `PASS`/`FAIL` summary, and writes a Markdown status table to
+  * `$$GITHUB_STEP_SUMMARY` (when set) or to `target/fix-check-summary.md`, so the report can be surfaced as a GitHub
+  * Actions job summary. Local (non-CI) invocations stay quiet.
+  *
+  * Additional steps can be plugged in via the `fixExtra` (write mode) and `fixCheckExtra` (check mode) settings; they
+  * run after the built-in scalafmt/scalafix steps.
   */
 object FixCommandPlugin extends AutoPlugin {
 
   object autoImport {
 
-    val fix = inputKey[Unit]("Launch both scalafmt and scalafix in all supported configurations")
+    val fix = inputKey[Unit] {
+      "Launch both scalafmt and scalafix in all supported configurations"
+    }
 
-    val fixExtra = settingKey[Seq[Def.Initialize[Task[Unit]]]](
+    val ci = taskKey[Unit] {
+      "Alias for `fix --check`"
+    }
+
+    val fixExtra = settingKey[Seq[Def.Initialize[Task[Unit]]]] {
       "Additional tasks chained after the built-in scalafmt/scalafix steps when `fix` is invoked"
-    )
+    }
 
-    val fixCheckExtra = settingKey[Seq[Def.Initialize[Task[Unit]]]](
-      "Additional tasks chained after the built-in scalafmt/scalafix checks when `fix --check` is invoked"
-    )
+    val fixCheckExtra = settingKey[Seq[NamedCheck]] {
+      "Additional checks chained after the built-in scalafmt/scalafix checks when `fix --check` is invoked"
+    }
+
+    /** A named check in the `fix --check` pipeline.
+      *
+      * The `name` is what appears in the per-check banner and in the Markdown summary table; `task` is the underlying
+      * check to run.
+      */
+    final case class NamedCheck(name: String, task: Def.Initialize[Task[Unit]]) {
+
+      /** Returns a copy of this check with the given display name. */
+      def named(newName: String): NamedCheck = copy(name = newName)
+
+      /** Returns a copy of this check with its underlying task replaced by the result of applying `f` to it.
+        *
+        * Useful for wrapping the task with `.acrossAggregated`, retries, timing, etc., without losing the check's
+        * label.
+        */
+      def mapTask(f: Def.Initialize[Task[Unit]] => Def.Initialize[Task[Unit]]): NamedCheck = copy(task = f(task))
+
+    }
+
+    /** Adds combinators to a `Def.Initialize[Task[Unit]]` so it can be turned into a [[NamedCheck]] or fanned out
+      * across all projects aggregated by the current one.
+      */
+    implicit class NamedCheckOps(private val task: Def.Initialize[Task[Unit]]) extends AnyVal {
+
+      /** Wraps this task as a [[NamedCheck]] with the given display name. */
+      def named(name: String): NamedCheck = NamedCheck(name, task)
+
+      /** Evaluates this task at every project aggregated by the project where `fix` / `fix --check` is invoked.
+        *
+        * Gives `fix` and `fix --check` the same multi-project coverage that sbt's task aggregation would provide,
+        * without relying on aggregation of the `fix` task itself.
+        */
+      def acrossAggregated: Def.Initialize[Task[Unit]] =
+        Def.task(task.all(ScopeFilter(inAggregates(ThisProject))).value).map(_ => ())
+
+    }
 
   }
 
@@ -57,9 +106,16 @@ object FixCommandPlugin extends AutoPlugin {
 
   override def requires: Plugins = ScalafixPlugin && ScalafmtPlugin
 
-  val parser = Def.setting(sbt.complete.DefaultParsers.spaceDelimited("--check | -c"))
+  /** Disables aggregation for the `fix` and [[autoImport.ci]] tasks so a single invocation produces a single
+    * plan/banner/summary block. Multi-project coverage is achieved internally via
+    * [[autoImport.NamedCheckOps.acrossAggregated]].
+    */
+  override def globalSettings: Seq[Def.Setting[_]] = Seq(
+    fix / aggregate := false,
+    ci / aggregate  := false
+  )
 
-  private def chain(tasks: Seq[Def.Initialize[Task[Unit]]]) = tasks.reduce(Def.sequential(_, _))
+  val parser = Def.setting(sbt.complete.DefaultParsers.spaceDelimited("--check | -c"))
 
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
     fixExtra      := Seq.empty,
@@ -67,18 +123,116 @@ object FixCommandPlugin extends AutoPlugin {
     fix           := InputTask
       .createDyn(InputTask.initParserAsInput(parser))(Def.task[Seq[String] => Def.Initialize[Task[Unit]]] {
         case Seq("--check") | Seq("-c") =>
-          chain {
-            ThisProject / scalafmtCheckAll +: Compile / scalafmtSbtCheck +: scalafixAll.toTask(" --check") +:
-              fixCheckExtra.value
-          }
+          runChecks(
+            scalafmtCheckAll.acrossAggregated.named("scalafmt-check") +:
+              (Compile / scalafmtSbtCheck).acrossAggregated.named("scalafmt-sbt-check") +:
+              scalafixAll.toTask(" --check").acrossAggregated.named("scalafix-check") +: fixCheckExtra.value
+          )
 
         case Nil =>
-          chain(scalafixAll.toTask("") +: ThisProject / scalafmtAll +: Compile / scalafmtSbt +: fixExtra.value)
+          chain(
+            scalafixAll.toTask("").acrossAggregated +:
+              scalafmtAll.acrossAggregated +:
+              (Compile / scalafmtSbt).acrossAggregated +:
+              fixExtra.value
+          )
 
         case args =>
           sys.error(s"Invalid argument `${args.mkString(" ")}`. The only argument allowed is `--check`")
       })
-      .evaluated
+      .evaluated,
+    ci := fix.toTask(" --check").value
   )
+
+  ///////////
+  // Utils //
+  ///////////
+
+  private def chain(tasks: Seq[Def.Initialize[Task[Unit]]]) = tasks.reduce(Def.sequential(_, _))
+
+  /** True when running under CI (i.e. the `CI` env var is set). Gates the rich console/Markdown output produced by
+    * [[runChecks]] so local invocations stay quiet.
+    */
+  private def isCI: Boolean = sys.env.contains("CI")
+
+  /** Orchestrates a sequence of checks with continue-on-error semantics.
+    *
+    * Every check runs via `.result` so a failure does not abort the chain. After all checks complete, aborts via
+    * `sys.error` if any check failed.
+    *
+    * When [[isCI]] is true, also prints the ordered plan, logs a banner before each check, logs a `PASS`/`FAIL`
+    * summary, and writes a Markdown status table via [[writeMarkdownSummary]]. Local invocations stay quiet.
+    */
+  private def runChecks(checks: Seq[NamedCheck]): Def.Initialize[Task[Unit]] = Def.taskDyn {
+    val log = streams.value.log
+
+    if (isCI) {
+      log.info("==> CI checks plan:")
+      checks.foreach(check => log.info(s"  - ${check.name}"))
+    }
+
+    val tagged: Seq[Def.Initialize[Task[(String, Result[Unit])]]] = checks.map { check =>
+      Def.taskDyn {
+        if (isCI) {
+          log.info(s"==> ${check.name}")
+        }
+        check.task.map(_ => ()).result.map(r => check.name -> r)
+      }
+    }
+
+    val collected = tagged.foldLeft(Def.task(List.empty[(String, Result[Unit])])) { (acc, next) =>
+      Def.taskDyn {
+        val previous = acc.value
+        next.map(r => previous :+ r)
+      }
+    }
+
+    Def.task {
+      val results = collected.value
+      val failed  = results.collect { case (name, Inc(_)) => name }
+      val passed  = results.collect { case (name, Value(_)) => name }
+
+      if (isCI) {
+        log.info("==> CI checks summary:")
+        passed.foreach(name => log.info(s"  PASS  $name"))
+        failed.foreach(name => log.error(s"  FAIL  $name"))
+
+        writeMarkdownSummary((LocalRootProject / target).value, scalaVersion.value, results, log)
+      }
+
+      if (failed.nonEmpty)
+        sys.error(s"${failed.size} check(s) failed: ${failed.mkString(", ")}")
+    }
+  }
+
+  /** Writes the `fix --check` Markdown status table. Only invoked from [[runChecks]] when [[isCI]] is true.
+    *
+    * Appends to `$$GITHUB_STEP_SUMMARY` when that env var is set so the report surfaces on the GitHub Actions workflow
+    * run page; otherwise writes to `fix-check-summary.md` under the build's root project `target` directory. The
+    * `scalaVersion` is included in the heading so cross-built runs produce distinct, identifiable blocks.
+    */
+  private def writeMarkdownSummary(
+      rootTarget: File,
+      scalaVersion: String,
+      results: Seq[(String, Result[Unit])],
+      log: Logger
+  ): Unit = {
+    val md = new StringBuilder
+    md.append(s"# CI checks ($scalaVersion)\n\n")
+    md.append("| Check | Status |\n| --- | --- |\n")
+
+    results.foreach {
+      case (name, Value(_)) => md.append(s"| $name | PASS |\n")
+      case (name, Inc(_))   => md.append(s"| $name | FAIL |\n")
+    }
+
+    val output = sys.env
+      .get("GITHUB_STEP_SUMMARY")
+      .map(file(_))
+      .getOrElse(rootTarget / "fix-check-summary.md")
+
+    IO.append(output, md.toString)
+    log.info(s"==> wrote summary to `${output.getAbsolutePath}`")
+  }
 
 }


### PR DESCRIPTION
## :rocket: What's included in this PR?

- `fix --check` now runs every check even when an earlier one fails, so a single CI run surfaces every formatter/linter violation at once. Exits non-zero if any failed.
- New `ci` task as a per-project shorthand for `fix --check` (`my-project/ci` works too).
- When the `CI` environment variable is set, the run also prints a labelled banner per check, logs a `PASS`/`FAIL` summary, and writes a Markdown status table to `$GITHUB_STEP_SUMMARY` (or `target/fix-check-summary.md` if unset). Local invocations stay quiet.
- New `NamedCheck` wrapper for `fixCheckExtra` entries. `someTask.named("my-linter")` (via `NamedCheckOps`) is the recommended form; the explicit `NamedCheck("my-linter", someTask)` also works.
- `fix` and `ci` tasks no longer aggregate at the sbt-task level; multi-project coverage is achieved internally via a new `.acrossAggregated` combinator so a single invocation produces a single plan/summary block.
- `versionPolicyIntention := Compatibility.None` for this release (breaking change: `fixCheckExtra`'s element type became `NamedCheck`).