### PR TITLE
Generic `NamedCheckOps` so non-Unit tasks can use `.named`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 ThisBuild / scalaVersion                  := _root_.scalafix.sbt.BuildInfo.scala212
 ThisBuild / organization                  := "com.alejandrohdezma"
 ThisBuild / pluginCrossBuild / sbtVersion := "1.2.8"
-ThisBuild / versionPolicyIntention        := Compatibility.BinaryAndSourceCompatible
+ThisBuild / versionPolicyIntention        := Compatibility.None
 
 addCommandAlias("ci-test", "fix --check; versionPolicyCheck; mdoc")
 addCommandAlias("ci-docs", "github; mdoc; headerCreateAll")

--- a/modules/sbt-fix/src/main/scala/com/alejandrohdezma/sbt/fix/FixCommandPlugin.scala
+++ b/modules/sbt-fix/src/main/scala/com/alejandrohdezma/sbt/fix/FixCommandPlugin.scala
@@ -80,13 +80,15 @@ object FixCommandPlugin extends AutoPlugin {
 
     }
 
-    /** Adds combinators to a `Def.Initialize[Task[Unit]]` so it can be turned into a [[NamedCheck]] or fanned out
-      * across all projects aggregated by the current one.
+    /** Adds combinators to any `Def.Initialize[Task[A]]` so it can be turned into a [[NamedCheck]] or fanned out across
+      * all projects aggregated by the current one.
       */
-    implicit class NamedCheckOps(private val task: Def.Initialize[Task[Unit]]) extends AnyVal {
+    implicit class NamedCheckOps[A](private val task: Def.Initialize[Task[A]]) extends AnyVal {
 
-      /** Wraps this task as a [[NamedCheck]] with the given display name. */
-      def named(name: String): NamedCheck = NamedCheck(name, task)
+      /** Wraps this task as a [[NamedCheck]] with the given display name. The task's result is discarded — the check
+        * pipeline only cares whether the task succeeded.
+        */
+      def named(name: String): NamedCheck = NamedCheck(name, task.map(_ => ()))
 
       /** Evaluates this task at every project aggregated by the project where `fix` / `fix --check` is invoked.
         *


### PR DESCRIPTION
## :computer: How to review this PR?

This PR was created with the idea of being reviewed commit by commit. Each commit contains an incremental change that makes it easier to review. Also some of the commits contain additional information in their description to help understand why the change was made.

<details><summary><b>I also recommend checking "Hide whitespace" when reviewing this PR!</b></summary></br>


![](https://i0.wp.com/user-images.githubusercontent.com/2503052/137387087-91cc8458-9e11-44a9-8da0-f48251ec452c.gif?ssl=1)

</details>

## :rocket: What's included in this PR?

`NamedCheckOps` was pinned to `Def.Initialize[Task[Unit]]`, so bare task keys whose result type isn't `Unit` (sbt's `compile: TaskKey[CompileAnalysis]`, `doc: TaskKey[File]`, etc.) couldn't be wrapped into `fixCheckExtra` — the build failed to load with `value named is not a member of sbt.TaskKey[...]`.

This PR:

- Re-introduces the `[A]` type parameter on `NamedCheckOps` so any `Def.Initialize[Task[A]]` picks up `.named` / `.acrossAggregated`.
- Discards the result inside `.named` via `task.map(_ => ())`, preserving `NamedCheck.task: Def.Initialize[Task[Unit]]` (the orchestrator only cares whether a check succeeded).
- Bumps `versionPolicyIntention` to `Compatibility.None` for this release, since adding the type parameter is a binary-incompatible signature change.
- No README change needed — the documented usage (`someTask.named("…")`) is unchanged from the user's perspective; it just starts working for more `someTask` types.