### PR TITLE
Cross-build for sbt 1.x and sbt 2.x

### DIFF
--- a/.github/docs/README.md
+++ b/.github/docs/README.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-Add the following line to your `plugins.sbt` file:
+The plugin is available for both sbt 1.x and sbt 2.x. To install it, add the following line to your `plugins.sbt` file:
 
 ```sbt
 addSbtPlugin("com.alejandrohdezma" %% "sbt-fix" % "@VERSION@")

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.head_ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -62,23 +62,22 @@ jobs:
       fail-fast: false
       matrix:
         jdk:
-          - 11
           - 17
           - 21
           - 25
     steps:
       - name: Checkout project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           ref: ${{ github.head_ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
           fetch-depth: 0
 
       - name: Run Coursier Cache Action
-        uses: coursier/cache-action@bebeeb0e6f48ebad66d3783946588ecf43114433 # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.8.1.1
 
       - name: Run Coursier Setup Action
-        uses: coursier/setup-action@f7be3eb3dcef84a4e16fc8cd75c87beb2e5cbcc9 # v2.0.2
+        uses: coursier/setup-action@fd1707a76b027efdfb66ca79318b4d29b72e5a02 # v3.0.0
         with:
           jvm: liberica:${{ matrix.jdk }}
           apps: sbt

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
@@ -41,12 +41,12 @@ jobs:
         uses: alejandrohdezma/actions/check-semver-tag@v1
 
       - name: Run Coursier Cache Action
-        uses: coursier/cache-action@bebeeb0e6f48ebad66d3783946588ecf43114433 # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.8.1.1
 
       - name: Run Coursier Setup Action
-        uses: coursier/setup-action@f7be3eb3dcef84a4e16fc8cd75c87beb2e5cbcc9 # v2.0.2
+        uses: coursier/setup-action@fd1707a76b027efdfb66ca79318b4d29b72e5a02 # v3.0.0
         with:
-          jvm: liberica:11
+          jvm: liberica:17
           apps: sbt
 
       - name: Run `sbt ci-publish`
@@ -65,17 +65,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
           ref: main
           ssh-key: ${{ secrets.GIT_DEPLOY_KEY }}
 
       - name: Run Coursier Cache Action
-        uses: coursier/cache-action@bebeeb0e6f48ebad66d3783946588ecf43114433 # v6.4.7
+        uses: coursier/cache-action@95e5b1029b6b86e7bac033ee44a0697d8a527d2d # v6.4.8.1.1
 
       - name: Run Coursier Setup Action
-        uses: coursier/setup-action@f7be3eb3dcef84a4e16fc8cd75c87beb2e5cbcc9 # v2.0.2
+        uses: coursier/setup-action@fd1707a76b027efdfb66ca79318b4d29b72e5a02 # v3.0.0
         with:
           jvm: liberica:17
           apps: sbt

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Installation
 
-Add the following line to your `plugins.sbt` file:
+The plugin is available for both sbt 1.x and sbt 2.x. To install it, add the following line to your `plugins.sbt` file:
 
 ```sbt
 addSbtPlugin("com.alejandrohdezma" %% "sbt-fix" % "0.12.0")

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ ThisBuild / scalaVersion                  := _root_.scalafix.sbt.BuildInfo.scala
 ThisBuild / crossScalaVersions            := Seq(scalaVersion.value, "3.8.4")
 ThisBuild / organization                  := "com.alejandrohdezma"
 ThisBuild / pluginCrossBuild / sbtVersion := scalaVersion.value.on(2)("1.2.8").getOrElse("2.0.0")
-ThisBuild / versionPolicyIntention        := Compatibility.BinaryAndSourceCompatible
+ThisBuild / versionPolicyIntention        := Compatibility.None
 
 addCommandAlias("ci-test", "fix --check; versionPolicyCheck; mdoc")
 addCommandAlias("ci-docs", "github; mdoc; headerCreateAll")

--- a/build.sbt
+++ b/build.sbt
@@ -1,6 +1,7 @@
 ThisBuild / scalaVersion                  := _root_.scalafix.sbt.BuildInfo.scala212
+ThisBuild / crossScalaVersions            := Seq(scalaVersion.value, "3.8.4")
 ThisBuild / organization                  := "com.alejandrohdezma"
-ThisBuild / pluginCrossBuild / sbtVersion := "1.2.8"
+ThisBuild / pluginCrossBuild / sbtVersion := scalaVersion.value.on(2)("1.2.8").getOrElse("2.0.0")
 ThisBuild / versionPolicyIntention        := Compatibility.BinaryAndSourceCompatible
 
 addCommandAlias("ci-test", "fix --check; versionPolicyCheck; mdoc")

--- a/build.sbt
+++ b/build.sbt
@@ -4,7 +4,7 @@ ThisBuild / organization                  := "com.alejandrohdezma"
 ThisBuild / pluginCrossBuild / sbtVersion := scalaVersion.value.on(2)("1.2.8").getOrElse("2.0.0")
 ThisBuild / versionPolicyIntention        := Compatibility.None
 
-addCommandAlias("ci-test", "fix --check; versionPolicyCheck; mdoc")
+addCommandAlias("ci-test", "fix --check; +versionPolicyCheck; mdoc; +publishLocal")
 addCommandAlias("ci-docs", "github; mdoc; headerCreateAll")
 addCommandAlias("ci-publish", "versionCheck; github; ci-release")
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,10 +1,10 @@
 ThisBuild / scalaVersion                  := _root_.scalafix.sbt.BuildInfo.scala212
 ThisBuild / crossScalaVersions            := Seq(scalaVersion.value, "3.8.4")
 ThisBuild / organization                  := "com.alejandrohdezma"
-ThisBuild / pluginCrossBuild / sbtVersion := scalaVersion.value.on(2)("1.2.8").getOrElse("2.0.0")
+ThisBuild / pluginCrossBuild / sbtVersion := scalaVersion.value.on(2)("1.12.12").getOrElse("2.0.0")
 ThisBuild / versionPolicyIntention        := Compatibility.None
 
-addCommandAlias("ci-test", "fix --check; +versionPolicyCheck; mdoc; +publishLocal")
+addCommandAlias("ci-test", "fix --check; +versionPolicyCheck; mdoc; +publishLocal; +scripted")
 addCommandAlias("ci-docs", "github; mdoc; headerCreateAll")
 addCommandAlias("ci-publish", "versionCheck; github; ci-release")
 
@@ -17,5 +17,6 @@ lazy val documentation = project
 
 lazy val `sbt-fix` = module
   .enablePlugins(SbtPlugin)
+  .settings(scriptedLaunchOpts += s"-Dplugin.version=${version.value}")
   .settings(addSbtPlugin(scalafix))
   .settings(addSbtPlugin(scalafmt))

--- a/modules/sbt-fix/src/main/scala/com/alejandrohdezma/sbt/fix/FixCommandPlugin.scala
+++ b/modules/sbt-fix/src/main/scala/com/alejandrohdezma/sbt/fix/FixCommandPlugin.scala
@@ -218,9 +218,9 @@ object FixCommandPlugin extends AutoPlugin {
               if (isCI) log.info(s"==> ${check.name}")
 
               check.task.map(_ => ()).result.map { r =>
-                val outcome = r match {
-                  case Value(_) => CheckResult.Passed
-                  case Inc(_)   => CheckResult.Failed
+                val outcome = r.toEither match {
+                  case Right(_) => CheckResult.Passed
+                  case Left(_)  => CheckResult.Failed
                 }
 
                 previous :+ (check -> outcome)

--- a/modules/sbt-fix/src/main/scala/com/alejandrohdezma/sbt/fix/FixCommandPlugin.scala
+++ b/modules/sbt-fix/src/main/scala/com/alejandrohdezma/sbt/fix/FixCommandPlugin.scala
@@ -136,8 +136,8 @@ object FixCommandPlugin extends AutoPlugin {
   override def projectSettings: Seq[Def.Setting[_]] = Seq(
     fixExtra      := Seq.empty,
     fixCheckExtra := Seq.empty,
-    fix           := InputTask
-      .createDyn(InputTask.initParserAsInput(parser))(Def.task[Seq[String] => Def.Initialize[Task[Unit]]] {
+    fix           := Def.inputTaskDyn {
+      parser.parsed match {
         case Seq("--check") | Seq("-c") =>
           runChecks {
             scalafmtCheckAll.acrossAggregated.named("scalafmt") +:
@@ -155,8 +155,8 @@ object FixCommandPlugin extends AutoPlugin {
 
         case args =>
           sys.error(s"Invalid argument `${args.mkString(" ")}`. The only argument allowed is `--check`")
-      })
-      .evaluated,
+      }
+    }.evaluated,
     ci := fix.toTask(" --check").value
   )
 

--- a/modules/sbt-fix/src/main/scala/com/alejandrohdezma/sbt/fix/FixCommandPlugin.scala
+++ b/modules/sbt-fix/src/main/scala/com/alejandrohdezma/sbt/fix/FixCommandPlugin.scala
@@ -126,14 +126,14 @@ object FixCommandPlugin extends AutoPlugin {
     * plan/banner/summary block. Multi-project coverage is achieved internally via
     * [[autoImport.NamedCheckOps.acrossAggregated]].
     */
-  override def globalSettings: Seq[Def.Setting[_]] = Seq(
+  override def globalSettings = Seq(
     fix / aggregate := false,
     ci / aggregate  := false
   )
 
   val parser = Def.setting(sbt.complete.DefaultParsers.spaceDelimited("--check | -c"))
 
-  override def projectSettings: Seq[Def.Setting[_]] = Seq(
+  override def projectSettings = Seq(
     fixExtra      := Seq.empty,
     fixCheckExtra := Seq.empty,
     fix           := Def.inputTaskDyn {

--- a/modules/sbt-fix/src/sbt-test/sbt-fix/fix-and-check/.scalafix.conf
+++ b/modules/sbt-fix/src/sbt-test/sbt-fix/fix-and-check/.scalafix.conf
@@ -1,0 +1,1 @@
+rules = [DisableSyntax]

--- a/modules/sbt-fix/src/sbt-test/sbt-fix/fix-and-check/.scalafmt.conf
+++ b/modules/sbt-fix/src/sbt-test/sbt-fix/fix-and-check/.scalafmt.conf
@@ -1,0 +1,2 @@
+version = "3.8.3"
+runner.dialect = scala212

--- a/modules/sbt-fix/src/sbt-test/sbt-fix/fix-and-check/project/plugins.sbt
+++ b/modules/sbt-fix/src/sbt-test/sbt-fix/fix-and-check/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("com.alejandrohdezma" % "sbt-fix" % sys.props("plugin.version"))
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.14.7")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.6.1")

--- a/modules/sbt-fix/src/sbt-test/sbt-fix/fix-and-check/src/main/scala/Foo.scala
+++ b/modules/sbt-fix/src/sbt-test/sbt-fix/fix-and-check/src/main/scala/Foo.scala
@@ -1,0 +1,3 @@
+object Foo {
+  def bar(a:Int, b:Int) = a+b
+}

--- a/modules/sbt-fix/src/sbt-test/sbt-fix/fix-and-check/test
+++ b/modules/sbt-fix/src/sbt-test/sbt-fix/fix-and-check/test
@@ -1,0 +1,8 @@
+# fix --check fails while the sources are not formatted
+-> fix --check
+
+# fix reformats the sources (scalafmt) and runs scalafix
+> fix
+
+# fix --check now passes
+> fix --check

--- a/project/dependencies.conf
+++ b/project/dependencies.conf
@@ -1,7 +1,7 @@
 sbt-build = [
   "ch.epfl.scala:sbt-scalafix:0.14.6:sbt-plugin"
   "ch.epfl.scala:sbt-version-policy:3.2.1:sbt-plugin"
-  "com.alejandrohdezma:sbt-ci:3.0.0:sbt-plugin"
+  "com.alejandrohdezma:sbt-ci:4.0.0:sbt-plugin"
   "com.alejandrohdezma:sbt-github-header:0.13.0:sbt-plugin"
   "com.alejandrohdezma:sbt-github-mdoc:0.13.0:sbt-plugin"
   "com.alejandrohdezma:sbt-modules:0.4.1:sbt-plugin"


### PR DESCRIPTION
## :computer: How to review this PR?

This PR was created with the idea of being reviewed commit by commit. Each commit contains an incremental change that makes it easier to review. Also some of the commits contain additional information in their description to help understand why the change was made.

<details><summary><b>I also recommend checking "Hide whitespace" when reviewing this PR!</b></summary></br>


![](https://i0.wp.com/user-images.githubusercontent.com/2503052/137387087-91cc8458-9e11-44a9-8da0-f48251ec452c.gif?ssl=1)

</details>

## :rocket: What's included in this PR?

Cross-builds the plugin so it publishes both `sbt-fix_2.12_1.0` (sbt 1.x / Scala 2.12) and `sbt-fix_sbt2_3` (sbt 2.x / Scala 3) from one codebase.

**Source** — three cross-valid changes in `FixCommandPlugin.scala`:

- `fix` rewritten with `Def.inputTaskDyn` (sbt 2 removed `InputTask.initParserAsInput`).
- `Result#toEither` instead of matching `Value` / `Inc` (`Result` is a Scala 3 `enum` in sbt 2).
- dropped the `Seq[Def.Setting[_]]` wildcard return types (fatal under Scala 3 `-Werror`).

**Build**:

- `crossScalaVersions` + the per-axis sbt version (`scalaVersion.value.on(2)("1.12.12").getOrElse("2.0.0")`).
- `versionPolicyIntention := Compatibility.None` for this release: dropping the wildcard return types changes the 2.12 generic signature (binary-compatible, but versionPolicy flags it as `IncompatibleSignatureProblem`), and the new `sbt-fix_sbt2_3` artifact has no prior release to compare against.
- `ci-test` cross-runs `+versionPolicyCheck`, `+publishLocal` and `+scripted`.

**Tests** — a scripted test (`fix-and-check`) covering `fix --check` → `fix` → `fix --check`, running on both sbt 1.x and sbt 2.x.

**Docs** — note that the plugin supports both sbt 1.x and 2.x.

> [!NOTE]
> The sbt 1.x floor is `1.12.12`: scripted runs on `pluginCrossBuild / sbtVersion`, and sbt < 1.12 cannot boot on JDK 25 while sbt-scalafmt 2.6.1 requires sbt 1.12.9+.
