### PR TITLE
Surface failed checks' underlying causes in `fix --check`

### DIFF
--- a/modules/sbt-fix/src/main/scala/com/alejandrohdezma/sbt/fix/FixCommandPlugin.scala
+++ b/modules/sbt-fix/src/main/scala/com/alejandrohdezma/sbt/fix/FixCommandPlugin.scala
@@ -219,8 +219,21 @@ object FixCommandPlugin extends AutoPlugin {
 
               check.task.map(_ => ()).result.map { r =>
                 val outcome = r.toEither match {
-                  case Right(_) => CheckResult.Passed
-                  case Left(_)  => CheckResult.Failed
+                  case Right(_)         => CheckResult.Passed
+                  case Left(incomplete) =>
+                    // Running through `.result` suppresses SBT's own reporting for the wrapped task, which
+                    // would otherwise hide failures whose details only live in the exception message (e.g.
+                    // `update`'s eviction report), so surface every underlying cause here.
+                    Incomplete
+                      .allExceptions(incomplete)
+                      .foreach { throwable =>
+                        Option(throwable.getMessage)
+                          .getOrElse(throwable.toString)
+                          .linesIterator
+                          .foreach(line => log.error(s"[${check.name}] $line"))
+                      }
+
+                    CheckResult.Failed
                 }
 
                 previous :+ (check -> outcome)


### PR DESCRIPTION
Checks run through `.result` so one failure doesn't abort the pipeline, but that also suppresses SBT's own error reporting for the wrapped task. Failures whose details only live in the exception message were reduced to `N check(s) failed: ...` with nothing actionable in the log — most painfully `update`'s eviction report, where the entire conflict tree is the exception message.

Now every failed check logs its underlying causes (via `Incomplete.allExceptions`) prefixed with the check's name, e.g.:

```
[error] [compatibility] 	* com.example:library-core_2.13:2.0.0 (early-semver) is selected over 1.0.0 for compile
[error] [compatibility] 	    +- com.example:app_2.13:1.5.0 (depends on 1.0.0)
[error] [compatibility] this can be overridden using libraryDependencySchemes or evictionErrorLevel
[error] (app / fix) 1 check(s) failed: compatibility
```

Verified end to end against a build with a deliberately planted eviction conflict wired into `fixCheckExtra` as an `update` check. `versionPolicyCheck` passes (`BinaryAndSourceCompatible` — internal change only).